### PR TITLE
Fix team code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@47deg/kashyyyk-jedha
+@47degrees/kashyyyk-jedha


### PR DESCRIPTION
Hi team,

It seems the name of the team belongs to another organization. So this is to fix this so it can appear when we filter.